### PR TITLE
Hot Fix: sinc_function exercise

### DIFF
--- a/exercises/sinc_function/sinc_function_solution.ipynb
+++ b/exercises/sinc_function/sinc_function_solution.ipynb
@@ -89,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "r = np.sqrt(x**2 + y**2)"
+    "r = sqrt(x**2 + y**2)"
    ]
   },
   {


### PR DESCRIPTION
`np.sqrt()` -> `sqrt()`